### PR TITLE
Profile Updates

### DIFF
--- a/client/components/Profile.jsx
+++ b/client/components/Profile.jsx
@@ -184,7 +184,7 @@ const Profile = () => {
           <div>
             <input
               name="password"
-              type="text"
+              type="password"
               placeholder={userData.password}
               onChange={handleUserDataChange}
             />

--- a/client/components/Profile.jsx
+++ b/client/components/Profile.jsx
@@ -13,7 +13,7 @@ const Profile = () => {
   const [userData, setUserData] = useState({
     name: "",
     latName: "",
-    email: "",
+    password: "",
     address: "",
     instructions: "",
   });
@@ -96,7 +96,7 @@ const Profile = () => {
     const data = {
       name: userData.name,
       lastName: userData.lastName,
-      email: userData.email,
+      password: userData.password,
       address: userData.address,
       instructions: userData.instructions,
     };
@@ -180,12 +180,12 @@ const Profile = () => {
             />
           </div>
 
-          <div>Email</div>
+          <div>Password</div>
           <div>
             <input
-              name="email"
-              type="email"
-              placeholder={userData.email}
+              name="password"
+              type="text"
+              placeholder={userData.password}
               onChange={handleUserDataChange}
             />
           </div>

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -175,19 +175,19 @@ userController.verifyUser = (req, res, next) => {
 
 userController.updateUserProfile = async (req, res, next) => {
   console.log("update user profile running");
-  const { name, lastName, email, address, instructions } = req.body;
+  const { name, lastName, password, address, instructions } = req.body;
   console.log(
     "name, email, address and instructions are ",
     name,
     lastName,
-    email,
+    password,
     address,
     instructions
   );
   try {
     const updatedUser = await User.findOneAndUpdate(
       { username: res.locals.user.username },
-      { name, lastName, email, address, instructions },
+      { name, lastName, password, address, instructions },
       { new: true }
     );
     res.locals.user = updatedUser;


### PR DESCRIPTION
## Description
Issue: once you update your email in the Profile page, you are unable to login with google Oauth anymore.
Solution is: allow user to update the password, but don't allow to update the email. So the email will be permanent records in the db.

## Changes
Update the Profile page, as well as the updateUserProfile routes. Replace the email with password. Thus no entry for updating email.

## Related Issues
None.
