### PR TITLE
Fixed styling for address list on Profile and Sign up pages

### DIFF
--- a/client/components/Profile.jsx
+++ b/client/components/Profile.jsx
@@ -183,7 +183,6 @@ const Profile = () => {
             <input
               name="password"
               type="password"
-              placeholder={userData.password}
               onChange={handleUserDataChange}
             />
           </div>

--- a/client/components/Profile.jsx
+++ b/client/components/Profile.jsx
@@ -61,14 +61,12 @@ const Profile = () => {
     const suggestion_items = {
         cursor: "pointer",
         padding: "10px",
-        border: "1px solid #ddd",
         margin: "5px",
         transition: "background-color 0.3s ease",
-        // position: "absolute",
         top: "100%",
         left: 0,
-        maxHeight: "200px"
-    }
+        maxHeight: "200px",
+      }
 
   const renderSuggestions = () =>
     data.map((suggestion) => {
@@ -78,7 +76,7 @@ const Profile = () => {
       } = suggestion;
 
       return (
-        <li key={place_id} style={suggestion_items} onClick={handleAddressSelect(suggestion)}>
+        <li key={place_id} className="addressSuggestion" style={suggestion_items} onClick={handleAddressSelect(suggestion)}>
           <strong>{main_text}</strong> <small>{secondary_text}</small>
         </li>
       );
@@ -200,7 +198,7 @@ const Profile = () => {
               onChange={handleAddressInput}
               disabled={!ready}
             />
-            {status === "OK" && <ul>{renderSuggestions()}</ul>}
+            {status === "OK" && <ul className='addressList'>{renderSuggestions()}</ul>}
           </div>
 
           <div>Pick up instructions (Optional)</div>

--- a/client/components/SignUp.jsx
+++ b/client/components/SignUp.jsx
@@ -62,7 +62,6 @@ const SignUp = () => {
   const suggestion_items = {
     cursor: "pointer",
     padding: "10px",
-    border: "1px solid #ddd",
     margin: "5px",
     transition: "background-color 0.3s ease",
     top: "100%",
@@ -82,6 +81,7 @@ const SignUp = () => {
           key={place_id}
           style={suggestion_items}
           onClick={handleAddressSelect(suggestion)}
+          className="addressSuggestion"
         >
           <strong>{main_text}</strong> <small>{secondary_text}</small>
         </li>
@@ -184,7 +184,7 @@ const SignUp = () => {
             onChange={handleAddressInput}
             disabled={!ready}
           />
-          {status === "OK" && <ul>{renderSuggestions()}</ul>}
+          {status === "OK" && <ul className="addressList">{renderSuggestions()}</ul>}
         </div>
 
         <div>Pick up instructions (Optional)</div>

--- a/client/styles.css
+++ b/client/styles.css
@@ -197,3 +197,14 @@ h1 {
 ul {
   list-style: none;
 }
+
+.addressList {
+  position: absolute;
+  background-color: #F4F2E9 ;
+  border-radius: 8px;
+
+}
+
+.addressSuggestion:hover{
+  background-color: #e2ddc7 ;
+}


### PR DESCRIPTION
## Description
The purpose of this pull request is to provide a fix for styling issues that were found in the Profile and the Sign up pages. Before this branch, whenever the address suggestions would get populated, the list would push the divs that were below the unordered list div downwards. 
## Changes
Positioned the ul to be of absolute position and gave it a background color. Also gave each li in the list a hover to darken the color on hover. Rounder the borders on the address suggestions div. 

## Checklist
- [x] I have tested the changes locally
- [x] I have resolved any merge conflicts

<img width="1440" alt="Screenshot 2024-01-31 at 7 53 37 PM" src="https://github.com/Ptri13-Team-Rocket/bookswap/assets/140472529/6f710b05-c8c4-4302-afbb-64ff4f7b1176">

<img width="973" alt="Screenshot 2024-01-31 at 7 52 41 PM" src="https://github.com/Ptri13-Team-Rocket/bookswap/assets/140472529/ade6a6d5-b111-404c-8ef0-38aa0f2205cb">

